### PR TITLE
Accept OpenCL 2.1 as a valid version

### DIFF
--- a/src/cpp/invoke/OpenCLJNI.cpp
+++ b/src/cpp/invoke/OpenCLJNI.cpp
@@ -442,6 +442,7 @@ JNI_JAVA(jobject, OpenCLJNI, getPlatforms)
             if (   !strncmp(platformVersionName, "OpenCL 1.2", 10)
                 || !strncmp(platformVersionName, "OpenCL 1.1", 10)
 				|| !strncmp(platformVersionName, "OpenCL 2.0", 10)
+				|| !strncmp(platformVersionName, "OpenCL 2.1", 10)
 #ifdef __APPLE__
                 || !strncmp(platformVersionName, "OpenCL 1.0", 10)
 #endif


### PR DESCRIPTION
This allows newer AMD drivers that return "OpenCL 2.1" as the platform version to be detected:

> \# clinfo | grep "Platform Version"
> Platform Version: OpenCL 1.2
> Platform Version: OpenCL 1.2 CUDA 9.1.84
> Platform Version: OpenCL 2.1 AMD-APP (2527.8)