### PR TITLE
Fix: local arrays handling 1D and ND, to cope with arrays resizing across kernel executions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Aparapi jni Change Log
 
+## 1.3.2
+
+* Fixed local arrays handling 1D and ND, to cope with arrays resizing across kernel executions
+
 ## 1.3.1
 
 * Fixed JVM crash with multi-dimensional arrays in Local memory (2D and 3D local arrays are now supported)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@ jni# Aparapi jni Changelog
 
 ## 1.3.2
 
-## 1.3.2
-
 * Fixed local arrays handling 1D and ND, to cope with arrays resizing across kernel executions
 
 ## 1.3.1

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -28,3 +28,4 @@ Below are some of the specific details of various contributions.
 * Paul Miner issue #61 and #115 (JTP Speed up and fixes to explicit puts) June 13th 2013
 & lgalluci for his fix for issue #121 (incorrect toString for 3D ranges) July 6th 2013
 * Luis Mendes Issue #51 JVM crash when using multi-dimensional local arrays (refs #51)
+* Luis Mendes submitted local arrays handling 1D and ND, to cope with arrays resizing across kernel executions

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([libaparapi], [1.2.1], [syncleus@syncleus.com])
+AC_INIT([libaparapi], [1.3.2], [syncleus@syncleus.com])
 AC_ENABLE_SHARED(yes)
 AC_ENABLE_STATIC(no)
 LT_INIT

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([libaparapi], [1.2.2], [syncleus@syncleus.com])
+AC_INIT([libaparapi], [1.3.2], [syncleus@syncleus.com])
 AC_ENABLE_SHARED(yes)
 AC_ENABLE_STATIC(no)
 LT_INIT

--- a/src/cpp/runKernel/Aparapi.cpp
+++ b/src/cpp/runKernel/Aparapi.cpp
@@ -258,7 +258,7 @@ jint updateNonPrimitiveReferences(JNIEnv *jenv, jobject jobj, JNIContext* jniCon
 
          //this won't be a problem with the aparapi buffers because
          //we need to copy them every time anyway
-         if (!arg->isPrimitive() && !arg->isAparapiBuffer()) {
+         if (!arg->isPrimitive() && !arg->isLocal() && !arg->isAparapiBuffer()) {
             // Following used for all primitive arrays, object arrays and nio Buffers
             jarray newRef = (jarray)jenv->GetObjectField(arg->javaArg, KernelArg::javaArrayFieldID);
             if (config->isVerbose()){
@@ -304,10 +304,10 @@ jint updateNonPrimitiveReferences(JNIEnv *jenv, jobject jobj, JNIContext* jniCon
                }
 
                // Save the lengthInBytes which was set on the java side
-               arg->syncSizeInBytes(jenv);
+               int lengthInBytes = arg->getSizeInBytes(jenv);
 
                if (config->isVerbose()){
-                  fprintf(stderr, "updateNonPrimitiveReferences, args[%d].lengthInBytes=%d\n", i, arg->arrayBuffer->lengthInBytes);
+                  fprintf(stderr, "updateNonPrimitiveReferences, args[%d].lengthInBytes=%d\n", i, lengthInBytes);
                }
             } // object has changed
          }
@@ -356,6 +356,7 @@ void updateArray(JNIEnv* jenv, JNIContext* jniContext, KernelArg* arg, int& argP
    else if (arg->isMutableByKernel()) mask |= CL_MEM_WRITE_ONLY;
    arg->arrayBuffer->memMask = mask;
 
+   arg->arrayBuffer->syncMinimalParams(jenv, arg);
    if (config->isVerbose()) {
       strcpy(arg->arrayBuffer->memSpec,"CL_MEM_USE_HOST_PTR");
       if (mask & CL_MEM_READ_WRITE) strcat(arg->arrayBuffer->memSpec,"|CL_MEM_READ_WRITE");
@@ -381,7 +382,6 @@ void updateArray(JNIEnv* jenv, JNIContext* jniContext, KernelArg* arg, int& argP
    // Add the array length if needed
    if (arg->usesArrayLength()) {
       argPos++;
-      arg->syncJavaArrayLength(jenv);
 
       status = clSetKernelArg(jniContext->kernel, argPos, sizeof(jint), &(arg->arrayBuffer->length));
       if(status != CL_SUCCESS) throw CLException(status,"clSetKernelArg (array length)");
@@ -629,15 +629,39 @@ void updateWriteEvents(JNIEnv* jenv, JNIContext* jniContext, KernelArg* arg, int
 void processLocalArray(JNIEnv* jenv, JNIContext* jniContext, KernelArg* arg, int& argPos, int argIdx) {
 
    cl_int status = CL_SUCCESS;
-   // what if local buffer size has changed?  We need a check for resize here.
-   if (jniContext->firstRun) {
+
+   cl_uint arrayLength;
+   int lengthInBytes;
+
+   arg->arrayBuffer->getMinimalParams(jenv, arg, arrayLength, lengthInBytes);
+
+   if (config->isVerbose()) {
+       fprintf(stderr, "runKernel local array arg %d %s - new[elems: %d, bytes: %d], old[elems: %d, bytes: %d]\n",
+               argIdx, arg->name, arrayLength, lengthInBytes, arg->arrayBuffer->length, arg->arrayBuffer->lengthInBytes);
+   }
+
+   bool changed = false;
+   if (lengthInBytes != arg->arrayBuffer->lengthInBytes) {
+	   changed = true;
+   }
+
+   if (!changed && arg->usesArrayLength() && arrayLength != arg->arrayBuffer->length) {
+       changed = true;
+   }
+
+
+   if (jniContext->firstRun || changed) {
+	  if (config->isVerbose()) {
+		  fprintf(stderr, "runKernel local array arg %d %s resize detected - adjusting args\n", argIdx, arg->name);
+	  }
+
+	  arg->arrayBuffer->syncMinimalParams(jenv, arg);
+
       status = arg->setLocalBufferArg(jenv, argIdx, argPos, config->isVerbose());
       if(status != CL_SUCCESS) throw CLException(status,"clSetKernelArg() (local)");
 
       // Add the array length if needed
       if (arg->usesArrayLength()) {
-         arg->syncJavaArrayLength(jenv);
-
          status = clSetKernelArg(jniContext->kernel, argPos, sizeof(jint), &(arg->arrayBuffer->length));
 
          if (config->isVerbose()){
@@ -645,9 +669,12 @@ void processLocalArray(JNIEnv* jenv, JNIContext* jniContext, KernelArg* arg, int
          }
 
          if(status != CL_SUCCESS) throw CLException(status,"clSetKernelArg (array length)");
-
       }
    } else {
+      if (config->isVerbose()) {
+         fprintf(stderr, "runKernel local array arg %d %s no resize detected - keeping args\n", argIdx, arg->name);
+      }
+
       // Keep the arg position in sync if no updates were required
       if (arg->usesArrayLength()) {
          argPos++;
@@ -669,14 +696,43 @@ void processLocalArray(JNIEnv* jenv, JNIContext* jniContext, KernelArg* arg, int
 void processLocalBuffer(JNIEnv* jenv, JNIContext* jniContext, KernelArg* arg, int& argPos, int argIdx) {
 
    cl_int status = CL_SUCCESS;
+
+   cl_uint numDims;
+   cl_uint dims[3];
+   int lengthInBytes;
+   arg->aparapiBuffer->getMinimalParams(jenv, arg, numDims, dims, lengthInBytes);
+
+   if (config->isVerbose()) {
+       fprintf(stderr, "runKernel local NDarray arg %d %s - new[bytes: %d], old[bytes: %d]\n",
+               argIdx, arg->name, lengthInBytes, arg->aparapiBuffer->lengthInBytes);
+   }
+
+
+   bool changed = false;
+   if (lengthInBytes != arg->aparapiBuffer->lengthInBytes) {
+	   changed = true;
+   }
+
+   if (!changed && arg->usesArrayLength()) {
+	   for (int i = 0; i < numDims; i++) {
+		   if (dims[i] != arg->aparapiBuffer->lens[i]) {
+			   changed = true;
+			   break;
+		   }
+	   }
+   }
+
    // what if local buffer size has changed?  We need a check for resize here.
-   if (jniContext->firstRun) {
+   if (jniContext->firstRun || changed) {
+	  if (config->isVerbose()) {
+		  fprintf(stderr, "runKernel local NDarray arg %d %s resize detected - adjusting args\n", argIdx, arg->name);
+	  }
+
 	  //To retrieve all fields of aparapiBuffer from Java for this local arg.
-	  arg->aparapiBuffer->flatten(jenv,arg);
+	  arg->aparapiBuffer->syncMinimalParams(jenv, arg);
 
       status = arg->setLocalAparapiBufferArg(jenv, argIdx, argPos, config->isVerbose());
       if(status != CL_SUCCESS) {
-    	  arg->aparapiBuffer->deleteBuffer(arg);
     	  throw CLException(status,"clSetKernelArg() (local)");
       }
 
@@ -684,36 +740,20 @@ void processLocalBuffer(JNIEnv* jenv, JNIContext* jniContext, KernelArg* arg, in
       if (arg->usesArrayLength()) {
          for(int i = 0; i < arg->aparapiBuffer->numDims; i++)
          {
-        	 if (arg->aparapiBuffer->lens == NULL) {
-				 std::string str = "runKernel arg " + patch::to_string(argIdx) + " " + arg->name +
-				 " - AparapiBuffer lens field is NULL at dim " + patch::to_string(i+1) + " of " +
-				 patch::to_string(arg->aparapiBuffer->numDims) + "\n";
-				 arg->aparapiBuffer->deleteBuffer(arg);
-				 throw CLException(CL_INVALID_VALUE, str.c_str());
-			  }
 			  int length = arg->aparapiBuffer->lens[i];
 			  argPos++;
 			  status = clSetKernelArg(jniContext->kernel, argPos, sizeof(cl_uint), &length);
 			  if(status != CL_SUCCESS) {
-				  arg->aparapiBuffer->deleteBuffer(arg);
 				  throw CLException(status,"clSetKernelArg (buffer length)");
 			  }
 			  if (config->isVerbose()){
 				 fprintf(stderr, "runKernel arg %d %s, length = %d\n", argIdx, arg->name, length);
 			  }
 
-			  if (arg->aparapiBuffer->offsets == NULL) {
-				 std::string str = "runKernel arg " + patch::to_string(argIdx) + " " + arg->name +
-				 " - AparapiBuffer offsets field is NULL at dim " + patch::to_string(i+1) + " of " +
-				 patch::to_string(arg->aparapiBuffer->numDims) + "\n";
-				 arg->aparapiBuffer->deleteBuffer(arg);
-				 throw CLException(CL_INVALID_VALUE, str.c_str());
-			  }
 			  int offset = arg->aparapiBuffer->offsets[i];
 			  argPos++;
 			  status = clSetKernelArg(jniContext->kernel, argPos, sizeof(cl_uint), &offset);
 			  if(status != CL_SUCCESS) {
-				  arg->aparapiBuffer->deleteBuffer(arg);
 				  throw CLException(status,"clSetKernelArg (buffer offset)");
 			  }
 			  if (config->isVerbose()){
@@ -721,10 +761,14 @@ void processLocalBuffer(JNIEnv* jenv, JNIContext* jniContext, KernelArg* arg, in
 			  }
          }
       }
-   } else {
+  } else {
+	  if (config->isVerbose()) {
+		  fprintf(stderr, "runKernel local NDarray arg %d %s no resize detected - keeping args\n", argIdx, arg->name);
+	  }
+
       // Keep the arg position in sync if no updates were required
       if (arg->usesArrayLength()) {
-         argPos += arg->aparapiBuffer->numDims;
+         argPos += arg->aparapiBuffer->numDims*2;
       }
    }
 }
@@ -969,14 +1013,6 @@ int getReadEvents(JNIEnv* jenv, JNIContext* jniContext) {
    cl_int status = CL_SUCCESS;
    for (int i=0; i< jniContext->argc; i++) {
       KernelArg *arg = jniContext->args[i];
-
-      if (arg->isLocal() && arg->isAparapiBuffer()) {
-    	  if (config->isVerbose()) {
-    		  fprintf(stderr, "Freeing local aparapi buffer for arg %d", arg->name);
-    	  }
-    	  arg->aparapiBuffer->deleteBuffer(arg);
-    	  continue;
-      }
 
       if (arg->needToEnqueueRead()){
          if (arg->isConstant()){

--- a/src/cpp/runKernel/AparapiBuffer.h
+++ b/src/cpp/runKernel/AparapiBuffer.h
@@ -72,20 +72,28 @@ private:
 
    void buildBuffer(void* _data, cl_uint* _dims, cl_uint _numDims, long _lengthInBytes, jobject _javaObject);
 
+   void computeOffsets();
+
 public:
-      jobject javaObject;       // The java array that this arg is mapped to 
-      cl_uint numDims;          // number of dimensions of the object (array lengths for ND arrays)
-      cl_uint* offsets;         // offsets of the next element in ND arrays)
-      cl_uint* lens;            // sizes of dimensions of the object (array lengths for ND arrays)
-      jint lengthInBytes;       // bytes in the array or directBuf
-      cl_mem mem;               // the opencl buffer 
-      void *data;               // a copy of the object itself (this is what we pass to OpenCL)
-      cl_uint memMask;          // the mask used for createBuffer
+   	  static int const MAX_ND_DIMS = 3;
+
+      jobject javaObject;           // The java array that this arg is mapped to
+      cl_uint numDims;              // number of dimensions of the object (array lengths for ND arrays)
+      cl_uint offsets[MAX_ND_DIMS]; // offsets of the next element in ND arrays) - Aparapi currently limits ND arrays to 3 dimensions
+      cl_uint lens[MAX_ND_DIMS];    // sizes of dimensions of the object (array lengths for ND arrays)
+      jint lengthInBytes;           // bytes in the array or directBuf
+      cl_mem mem;                   // the opencl buffer
+      void *data;                   // a copy of the object itself (this is what we pass to OpenCL)
+      cl_uint memMask;              // the mask used for createBuffer
       ProfileInfo read;
       ProfileInfo write;
 
       AparapiBuffer();
       AparapiBuffer(void* _data, cl_uint* _dims, cl_uint _numDims, long _lengthInBytes, jobject _javaObject);
+
+      void getMinimalParams(JNIEnv *env, KernelArg* arg, cl_uint &numDims, cl_uint dims[], int &lengthInBytes) const;
+
+      void syncMinimalParams(JNIEnv *env, KernelArg* arg);
 
       void deleteBuffer(KernelArg* arg);
 
@@ -129,7 +137,7 @@ public:
       void inflateFloat3D(JNIEnv *env, KernelArg* arg);
       void inflateDouble3D(JNIEnv *env, KernelArg* arg);
 
-      jobject getJavaObject(JNIEnv* env, KernelArg* arg);
+      jobject getJavaObject(JNIEnv* env, KernelArg* arg) const;
 };
 
 #endif // ARRAYBUFFER_H

--- a/src/cpp/runKernel/ArrayBuffer.cpp
+++ b/src/cpp/runKernel/ArrayBuffer.cpp
@@ -37,6 +37,7 @@
    */
 #define ARRAYBUFFER_SOURCE
 #include "ArrayBuffer.h"
+#include "KernelArg.h"
 
 ArrayBuffer::ArrayBuffer():
    javaArray((jobject) 0),
@@ -61,4 +62,14 @@ void ArrayBuffer::pin(JNIEnv *jenv){
    void *ptr = addr;
    addr = jenv->GetPrimitiveArrayCritical((jarray)javaArray,&isCopy);
    isPinned = JNI_TRUE;
+}
+
+void ArrayBuffer::getMinimalParams(JNIEnv *jenv, KernelArg *arg, cl_uint& arrayElements, int &sizeInBytes) {
+    arrayElements = JNIHelper::getInstanceField<jint>(jenv, arg->javaArg, "numElements", IntArg);
+    sizeInBytes = jenv->GetIntField(arg->javaArg, KernelArg::getSizeInBytesFieldID());
+}
+
+void ArrayBuffer::syncMinimalParams(JNIEnv *jenv, KernelArg *arg) {
+    length = JNIHelper::getInstanceField<jint>(jenv, arg->javaArg, "numElements", IntArg);
+	lengthInBytes = jenv->GetIntField(arg->javaArg, KernelArg::getSizeInBytesFieldID());
 }

--- a/src/cpp/runKernel/ArrayBuffer.h
+++ b/src/cpp/runKernel/ArrayBuffer.h
@@ -41,6 +41,8 @@
 #include "Common.h"
 #include "ProfileInfo.h"
 
+class KernelArg;
+
 class ArrayBuffer{
    public:
       jobject javaArray;        // The java array that this arg is mapped to 
@@ -59,6 +61,8 @@ class ArrayBuffer{
       void unpinAbort(JNIEnv *jenv);
       void unpinCommit(JNIEnv *jenv);
       void pin(JNIEnv *jenv);
+      void getMinimalParams(JNIEnv *jenv, KernelArg *arg, cl_uint& arrayElements, int &sizeInBytes);
+      void syncMinimalParams(JNIEnv *jenv, KernelArg *arg);
 };
 
 #endif // ARRAYBUFFER_H

--- a/src/cpp/runKernel/KernelArg.h
+++ b/src/cpp/runKernel/KernelArg.h
@@ -61,7 +61,11 @@ class KernelArg{
 
 
    public:
-      static jfieldID javaArrayFieldID; 
+      static jfieldID javaArrayFieldID;
+
+      static jfieldID getSizeInBytesFieldID(){
+    	  return sizeInBytesFieldID;
+      }
    public:
       JNIContext *jniContext;  
       jobject argObj;    // the Java KernelRunner.KernelArg object that we are mirroring. Do not use it outside constructor due to GC. Use javaArg instead.
@@ -174,12 +178,15 @@ class KernelArg{
       void syncType(JNIEnv* jenv){
          type = jenv->GetIntField(javaArg, typeFieldID);
       }
-      void syncSizeInBytes(JNIEnv* jenv){
-         arrayBuffer->lengthInBytes = jenv->GetIntField(javaArg, sizeInBytesFieldID);
+
+      int getSizeInBytes(JNIEnv* jenv){
+    	 return jenv->GetIntField(javaArg, sizeInBytesFieldID);
       }
-      void syncJavaArrayLength(JNIEnv* jenv){
-         arrayBuffer->length = jenv->GetIntField(javaArg, numElementsFieldID);
+
+      cl_uint getJavaArrayLength(JNIEnv* jenv){
+         return jenv->GetIntField(javaArg, numElementsFieldID);
       }
+
       void clearExplicitBufferBit(JNIEnv* jenv){
          type &= ~com_aparapi_internal_jni_KernelRunnerJNI_ARG_EXPLICIT_WRITE;
          jenv->SetIntField(javaArg, typeFieldID,type );


### PR DESCRIPTION
- Fixes 1D local arrays being handled as if they were global arrays
- Detection of 1D local arrays resizing across kernel executions
- Fixes multiple executions of the same kernel having ND local arrays
- Detection of ND local arrays resizing across kernel executions