### PR TITLE
Jdk10/issue12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.4.2
 
+* Fixed compiling with jdk above 8
+
 ## 1.4.1
 
 * Fixed exception handling when calling Java method OpenCLDevice.configure() to not hide exceptions

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@
 * Paul Miner
 * Lorenzo Gallucci
 * Luis Mendes <luis.p.mendes@gmail.com>
+* Sven Guenther <sven.guenther@gmail.com>
 
 # Details
 

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 mkdir include
 (cd java && mvn clean package -DskipTests=true -Dmaven.javadoc.skip=true)
-javah -jni -classpath ./java/target/classes -d include -force com.aparapi.internal.jni.ConfigJNI com.aparapi.internal.jni.KernelArgJNI com.aparapi.internal.jni.KernelRunnerJNI com.aparapi.internal.jni.OpenCLJNI com.aparapi.internal.jni.RangeJNI com.aparapi.Kernel com.aparapi.Range com.aparapi.Config com.aparapi.device.Device com.aparapi.device.OpenCLDevice com.aparapi.internal.kernel.KernelRunner com.aparapi.internal.opencl.OpenCLArgDescriptor com.aparapi.internal.opencl.OpenCLMem


### PR DESCRIPTION
tldr: Remove the usage of javah to support JDK above 8.

With the JDK8 the javah command is deprecated and is removed in jdk9, the function is now supported by the javac command. But the source code needs the java native annotation. The Patch removes the javah command from the prepare script.